### PR TITLE
Add .vercelignore and update configuration files for Vercel deployment

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,11 @@
+# Ignore everything in the root except frontend
+/*
+!frontend/
+!vercel.json
+
+# Other files to ignore
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+node_modules

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,18 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: 'standalone',
+  reactStrictMode: true,
+  swcMinify: true,
+  images: {
+    domains: ['oracle.degenplatform.io'],
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '**',
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "vercel-build": "pnpm install && pnpm build"
+    "vercel-build": "next build"
   },
   "dependencies": {
     "@coinbase/agentkit": "^0.8.2",

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,10 @@
 {
-  "rootDirectory": "frontend"
+  "version": 2,
+  "outputDirectory": "frontend/.next",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/frontend/$1"
+    }
+  ]
 }


### PR DESCRIPTION
This pull request includes changes to streamline the deployment configuration for a Next.js project hosted on Vercel. Key updates involve adjustments to `.vercelignore`, `next.config.ts`, `package.json`, and `vercel.json` to optimize the build process and improve deployment behavior.

### Deployment Configuration Updates:

* [`.vercelignore`](diffhunk://#diff-3e1371da71c2433196defa5f4470b9fd2a0fd2a3e8c7974d3a68bff89d6f0d9aR1-R11): Added rules to ignore everything in the root directory except the `frontend` folder and `vercel.json`, while explicitly ignoring environment files and `node_modules`.
* [`vercel.json`](diffhunk://#diff-a3265310f552fb66876e8bfe8809737e59e5ba946bdf39138b44d9baf4e21240L2-R9): Updated to specify `version: 2`, set the output directory to `frontend/.next`, and added rewrites to route requests to the `frontend` folder.

### Next.js Configuration Enhancements:

* [`frontend/next.config.ts`](diffhunk://#diff-7702f0833633e43f13b4cdfe6f086298da528924380b00f3ad0291071b0bb345L4-R15): Configured Next.js for standalone output, enabled strict mode and SWC minification, and added support for external images with specified domains and remote patterns.

### Build Process Simplification:

* [`frontend/package.json`](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L10-R10): Simplified the `vercel-build` script to only use `next build`, removing the `pnpm install` step.